### PR TITLE
[FIX] - Fix an issue with the feature export moodle badge

### DIFF
--- a/form/config.php
+++ b/form/config.php
@@ -48,7 +48,16 @@ class obf_config_form extends local_obf_form_base implements renderable {
 
         $formdata = $this->get_data();
         if ($errorcode === -1) {
-            $expires = userdate($client->get_certificate_expiration_date(),
+            // Prevent timestamp to be false.
+            // Export badge seems only legacyfeature and will work only for it as it is.
+            // Use oauth2_access_token expire date if needed as a workaround.
+            if ($client->get_certificate_expiration_date() === false && $client->oauth2_access_token()) {
+                $dateexpires = $client->oauth2_access_token()['token_expires'];
+            } else {
+                $dateexpires = $client->get_certificate_expiration_date();
+            }
+
+            $expires = userdate($dateexpires,
                 get_string('dateformatdate', 'local_obf'));
             $mform->addElement('html',
                 $OUTPUT->notification(get_string('connectionisworking',
@@ -57,8 +66,8 @@ class obf_config_form extends local_obf_form_base implements renderable {
             $mform->setType('deauthenticate', PARAM_INT);
             $mform->addElement('submit', 'submitbutton',
                 get_string('deauthenticate', 'local_obf'));
-        } else { // Connection is not working.
-
+        } else {
+            // Connection is not working.
             // We get error code 0 if pinging the API fails (like if the keyfiles
             // are missing). In plugin config we should show a more spesific
             // error to admin, so let's do that by changing the error code.
@@ -81,8 +90,6 @@ class obf_config_form extends local_obf_form_base implements renderable {
                 $mform->createElement('submit', 'submitbutton',
                     get_string('authenticate', 'local_obf')));
             $mform->addGroup($buttonarray, 'buttonar', '', array(' '), false);
-
         }
     }
-
 }

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2025031800; // YYYYMMDD.
+$plugin->version = 2025042901; // YYYYMMDD.
 $plugin->requires = 2022112800; // Moodle 4.1 version check.
 $plugin->component = 'local_obf';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '1.1.0';
+$plugin->release = '1.1.1';


### PR DESCRIPTION
No major issues found with Moodle 5.0 compatibility.

However, during testing, we encountered a bug with the Moodle-to-OBF badge export feature. The issue occurs because this feature relies on behavior specific to the legacy API. When using an OAuth2 client, the certification files are not created locally, which causes the export to fail due to missing files.

As a temporary workaround, I patched the logic to fall back on the OAuth2 token_expire_timestamp to ensure the process completes without error.

Since this issue is not specific to Moodle 5.0 (it was also reproduced on Moodle 4.5), it is not mandatory to fix it immediately or for the early bird release.