### PR TITLE
Add legacy API key button removed (MP-30)

### DIFF
--- a/config.php
+++ b/config.php
@@ -67,11 +67,11 @@ switch ($action) {
             echo '</div>';
 
             $newoauth2 = $CFG->wwwroot . '/local/obf/config.php?action=edit&id=0';
-            $newlegacy = $CFG->wwwroot . '/local/obf/config_legacy.php';
+
             echo '<div class="actionbuttons">';
             echo $OUTPUT->single_button($newoauth2, get_string('addnewoauth2', 'local_obf'), 'get');
-            echo ' &nbsp; ';
-            echo $OUTPUT->single_button($newlegacy, get_string('addnewlegacy', 'local_obf'), 'get');
+
+            
             echo '</div>';
         } else {
             $table = new html_table();

--- a/lang/en/local_obf.php
+++ b/lang/en/local_obf.php
@@ -26,7 +26,6 @@ $string['addcourses'] = 'Add selected courses';
 $string['addcriteria'] = 'Create new awarding rule';
 $string['addnew'] = 'Add new';
 $string['addnewclient'] = 'Add new client';
-$string['addnewlegacy'] = 'Add new legacy API connection';
 $string['addnewoauth2'] = 'Add new OAuth2 API connection';
 $string['addemaildescription'] =
     'Type your email address. If the address has not been verified, a verification code will be sent to that address.';


### PR DESCRIPTION
Add legacy API key button and equivalent translation removed from Site administration - Open Badges - General tab for users who have no API connections added 