### PR TITLE
Fix repeated OBF badge requests in course view

### DIFF
--- a/classes/badge.php
+++ b/classes/badge.php
@@ -671,34 +671,32 @@ class obf_badge {
         $criteria = obf_criterion::get_course_criterion($courseid);
         $badges = array();
 
-        // TODO: It appears that the categories are not returned in the simple API request.
-        //  "Single badge by ID: GET /v1/badge/{client_id}/{badge_id}".
-        //  In the meantime, this piece of code serves as a workaround.
-        //  but it would be desirable to have the categories at the correct level.
-        // If any rules are define on site we will prevent issue badge
-        // in case there is no rule for current categ badge and at last one define on site.
+        // If any category rules are defined, only include course badges that
+        // are available through the active OBF connection.
         $anyrulesdefinesql = "SELECT * FROM {local_obf_rulescateg}";
         $anyrules = $DB->get_records_sql($anyrulesdefinesql);
 
-        foreach ($criteria as $criterion) {
-            if ($clientid && $clientid !== $criterion->get_clientid()) {
-                continue;
-            }
+        $criteria = array_filter($criteria, function ($criterion) use ($clientid) {
+            return !$clientid || $clientid === $criterion->get_clientid();
+        });
 
-            if (!empty($anyrules)) {
-
-                $client = obf_client::get_instance();
-                $badgeslist = $client->get_badges();
-
-                foreach ($badgeslist as $badge) {
-                    if ($badge['id'] == $criterion->get_badge()->get_id()) {
-                        $allowdisplay = true;
-                    }
+        // Retrieve the remote badge list once per page request. Previously this
+        // happened once per criterion and could trigger the OBF API rate limit.
+        $availablebadgeids = null;
+        if (!empty($anyrules) && !empty($criteria)) {
+            $availablebadgeids = array();
+            $badgeslist = obf_client::get_instance()->get_badges();
+            foreach ($badgeslist as $badge) {
+                if (!empty($badge['id'])) {
+                    $availablebadgeids[$badge['id']] = true;
                 }
             }
+        }
 
-            if (isset($allowdisplay) || empty($anyrules)) {
-                $badges[] = $criterion->get_badge();
+        foreach ($criteria as $criterion) {
+            $badge = $criterion->get_badge();
+            if ($availablebadgeids === null || isset($availablebadgeids[$badge->get_id()])) {
+                $badges[] = $badge;
             }
         }
 


### PR DESCRIPTION
````markdown
Fixes #43

### Summary

Retrieve the remote OBF badge list once in `get_badges_in_course()` instead of once per course criterion.

The list is converted into a badge-ID lookup, and each criterion is evaluated independently.

### Problem

The previous implementation called:

`obf_client::get_instance()->get_badges();`

inside the criterion loop.

A course with five criteria therefore caused five additional badge-list requests during one page render. In the reported environment, this resulted in an HTTP 429 response from the OBF API v2 endpoint.

`$allowdisplay` also persisted between iterations, allowing later criteria to be displayed after an earlier badge matched.

The same repeated-request pattern exists in an older installation using the legacy `/v1/badge/{client_id}` endpoint. In testing, that installation was not affected by HTTP 429, even with six criteria. The reported failure was observed with API v2.

### Changes

- Filter criteria by the requested OBF client.
- Retrieve the remote badge list once when category rules are present.
- Build a badge-ID lookup.
- Evaluate each criterion independently.
- Remove the obsolete API v1 workaround comment.

### Behavioural impact

- Reduces badge-list retrievals from once per criterion to once per call to `get_badges_in_course()`.
- Preserves client filtering and category-rule enforcement.
- Does not introduce persistent caching.
- Does not modify issuing, revocation, completion processing, scheduled tasks, or database data.
- Prevents `$allowdisplay` from affecting later criteria.

### Verification

Tested with Moodle 4.5, `local_obf` 2.0.3, OAuth2, and OBF API v2.

Before the change, a course with five criteria returned HTTP 429. After the change, the page loaded successfully.

The following checks passed:
PHP syntax validation
